### PR TITLE
Filter measurements on Missson Screen

### DIFF
--- a/ps_missions/models/missions.py
+++ b/ps_missions/models/missions.py
@@ -120,6 +120,17 @@ class PopsMissions(models.Model):
         """Get Back mission to Draft"""
         self.state = 'draft'
 
+    @api.multi
+    def action_open_missions_measurement(self):
+        return {
+            'name': _('measurement'),
+            'domain': [('missions_id', '=', self.id)],
+            'view_type': 'form',
+            'res_model': 'pops.measurement',
+            'view_id': False,
+            'view_mode': 'tree,form',
+            'type': 'ir.actions.act_window'
+        }
 
 class PopsPhotoLine(models.Model):
     _name = 'pops.photo.lines'

--- a/ps_missions/views/missions_views.xml
+++ b/ps_missions/views/missions_views.xml
@@ -33,7 +33,7 @@
           </header>        
         	<sheet>    
             <div class="oe_button_box" name="button_box">
-              <button class="oe_stat_button" type="action" name="%(ps_missions.action_open_missions_measurement)d"
+              <button class="oe_stat_button" type="object" name="action_open_missions_measurement"
                   groups="ps_missions.group_missions_user"
                   icon="fa-book" title="Measurement count">
                   <field string="Measurement" name="measurement_count" widget="statinfo"/>


### PR DESCRIPTION
Correction of the following error: In the Missions screen, clicking on measurements is not filtering the measurements according to the previous mission.