### PR TITLE
Adicionar um Menu dentro do Item Instagram chamado Comment Analytics #14

### DIFF
--- a/instagram_analytics/__manifest__.py
+++ b/instagram_analytics/__manifest__.py
@@ -15,6 +15,7 @@
         'security/ir.model.access.csv',
         'views/sna_instagram_post_views.xml',
         'views/sna_instagram_config_views.xml',
-        'data/ir_cron_sna_instagram_config.xml'
+        'data/ir_cron_sna_instagram_config.xml',
+        'views/sna_instagram_comment_analytics.xml'
     ],
 }

--- a/instagram_analytics/models/sna_instagram_config.py
+++ b/instagram_analytics/models/sna_instagram_config.py
@@ -156,6 +156,12 @@ class InstagramConfig(models.Model):
 class SnaInstagramConfigContextAcount(models.Model):
   _name = 'sna.instagram.context.acount'
 
-  context_description = fields.Char()
-  context_sentiment = fields.Selection([('1', 'Positivo'), ('2', 'Negativo'), ('3', 'Neutro')])
+  context_description = fields.Char('Context Description')
+  context_sentiment = fields.Selection([('1', 'Positivo'), ('2', 'Negativo'), ('3', 'Neutro')], string = 'Context Sentiment')
   account_namelines_id = fields.Many2one('sna.instagram.config', 'Account name', ondelete='cascade', required=True)
+  def name_get (self):
+    result = []
+
+    for record in self:
+      result.append((record.id, record.context_description))
+    return result

--- a/instagram_analytics/models/sna_instagram_post.py
+++ b/instagram_analytics/models/sna_instagram_post.py
@@ -5,6 +5,7 @@ from odoo import models, fields, api
 
 class InstagramPost(models.Model):
     _name = 'sna.instagram.post'
+    _description = 'Instagram Post'
 
     post_id = fields.Char("Instagram Post ID")
     config_id = fields.Many2one('sna.instagram.config')
@@ -46,7 +47,14 @@ class InstagramPostHashtag(models.Model):
 class InstagramPostComment(models.Model):
     _name = 'sna.instagram.post.comment'
 
-    comment_id = fields.Char()
+    comment_id = fields.Char("Comment Id")
     comment_text = fields.Text()
-    post_id = fields.Many2one('sna.instagram.post', ondelete='cascade')
+    post_id = fields.Many2one('sna.instagram.post', ondelete='cascade', string='Post id')
+    post_id_ = fields.Integer(string='Id Post', related='post_id.id', readonly=True, store=True)
+    post_post_id = fields.Char(string='Post id Instagram', related='post_id.post_id', readonly=True, store=True)
+    partner_id = fields.Many2one('res.partner', related='post_id.partner_id', readonly=True, store=True)
+    config_id = fields.Many2one('sna.instagram.config', related='post_id.config_id', readonly=True, store=True)
+    context_id = fields.Many2one('sna.instagram.context.acount', string = 'Context')
+    context_description = fields.Char(related='context_id.context_description', readonly=True)
+    context_sentiment = fields.Selection(related='context_id.context_sentiment', readonly=True, store = True)
     date = fields.Datetime()

--- a/instagram_analytics/security/ir.model.access.csv
+++ b/instagram_analytics/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sna_instagram_analytics_config,sna_instagram_analytics.config,model_sna_instagram_config,,1,1,1,1
 access_sna_instagram_analytics_config_context_acount,model_sna_instagram_context_acount,model_sna_instagram_context_acount,,1,1,1,1
+access_sna_instagram_analytics_model_sna_instagram_post_comment,model_sna_instagram_post_comment,model_sna_instagram_post_comment,,1,1,1,1
 access_sna_instagram_analytics_post,sna_instagram_analytics.post,model_sna_instagram_post,,1,0,0,1
 access_sna_instagram_analytics_post_media,sna_instagram_analytics.post.media,model_sna_instagram_post_media,,1,0,0,1
 access_sna_instagram_analytics_post_hashtag,sna_instagram_analytics.post.hashtag,model_sna_instagram_post_hashtag,,1,1,1,1

--- a/instagram_analytics/views/sna_instagram_comment_analytics.xml
+++ b/instagram_analytics/views/sna_instagram_comment_analytics.xml
@@ -1,0 +1,70 @@
+<odoo>
+  <data>
+    <!-- explicit list view definition -->
+    <record model="ir.ui.view" id="sna_instagram_post_comment_list">
+      <field name="name">sna_instagram_post_comment list</field>
+      <field name="model">sna.instagram.post.comment</field>
+      <field name="arch" type="xml">
+        <tree decoration-info="context_sentiment=='1'" decoration-danger="context_sentiment=='2'" decoration-warning="context_sentiment=='3'">
+          <field name="partner_id"/>
+          <field name="post_id_"/>
+          <field name="context_description"/>
+          <field name="context_sentiment"/>
+          <field name="comment_text"/>
+          <field name="date"/>
+        </tree>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="sna_instagram_post_comment_form_view">
+      <field name="name">sna_instagram_post_comment form</field>
+      <field name="model">sna.instagram.post.comment</field>
+      <field name="arch" type="xml">
+        <form string="Comment Analytics">
+          <sheet>
+            <group>
+              <group col="2" colspan="2">
+                <field name="config_id" invisible="1"/>
+                <field name="context_id"  domain="[('account_namelines_id', '=', config_id)]"/>
+                <field name="context_sentiment" string = ""/>
+              </group>
+
+              <group col="2" colspan="2">
+                <field name="comment_text" readonly="1"/>
+              </group>
+
+              <group col="4" colspan="2">
+                <field name="partner_id" readonly="1"/>
+                <field name="date" readonly="1"/>
+                <field name="post_post_id" readonly="1"/>
+                <field name="comment_id" readonly="1"/>
+              </group>
+            </group>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="sna_instagram_post_comment_view_filter">
+	    <field name="name">sna.instagram.post.comment.filter</field>
+	    <field name="model">sna.instagram.post.comment</field>
+	    <field name="arch" type="xml">
+	        <search string="Search Instagram Post">
+<!--            <group expand="0" string="Group By">-->
+<!--              <filter string="Partner" name="partner_id" context="{'group_by':'partner_id'}"/>-->
+<!--            </group>-->
+	        </search>
+	    </field>
+    </record>
+
+    <!-- actions opening views on models -->
+    <record model="ir.actions.act_window" id="sna_instagram_comment_analytics_action">
+      <field name="name"> Comment Analytics</field>
+      <field name="res_model">sna.instagram.post.comment</field>
+      <field name="view_mode">tree,form,graph</field>
+      <field name="search_view_id" ref="sna_instagram_post_comment_view_filter"/>
+    </record>
+
+    <menuitem name="Comment Analytics" id="menu_sna_instagram_comment_analytics" parent="menu_instagram" action="sna_instagram_comment_analytics_action"/>
+  </data>
+</odoo>

--- a/instagram_analytics/views/sna_instagram_post_views.xml
+++ b/instagram_analytics/views/sna_instagram_post_views.xml
@@ -112,8 +112,8 @@
       <field name="code">action = model._start_getting_posts_all()</field>
     </record>
 
-    <menuitem name="Get Posts" id="menu_get_posts" parent="social_network_analytics_base.menu_root" action="start_getting_posts_all"/>
-    <menuitem name="Instagram" id="menu_instagram" parent="social_network_analytics_base.menu_root"/>
+    <menuitem name="Get Posts" id="menu_get_posts" parent="social_network_analytics_base.menu_root" action="start_getting_posts_all" sequence="20"/>
+    <menuitem name="Instagram" id="menu_instagram" parent="social_network_analytics_base.menu_root" sequence="10"/>
       <menuitem name="Posts" id="menu_sna_instagram_posts" parent="menu_instagram"
               action="sna_instagram_post_action"/>
   </data>


### PR DESCRIPTION
Este Menu irá levar para uma página onde serão listados todos os comentários estes deverão poder ser agrupados por conta. Estes deverão ser tratados como um modelo de dados independente no banco, por isso precisam ser migrados/replicados para o modelo sna.instagram.comment

Será necessário criar um modelo chamado: sna.instagram.comment e migrar os comentários que atualmente se encontram dentro de comments_ids << sna.instagram.post.

Será necessário também criar um script de migração similar aos vistos nos modelos da OCA de maneira a termos replicado o modelo antigo dentro de comments_ids_sna.instagram.post para termos um novo modelo chamado sna.instagram.comment

Este modelo deverá cumprir a seguinte arquitetura (colunas adicionais podem ser usadas)

No sna_instagram_comments os dados serão inseridos manualmente por um usuário. Seria interessante se o rest_framwork já estivesse funcionando para que isto seja feito manualmente depois via api por app ou um bot

|comment_id | sna_account_name | comment | comment_likes | sna_instagram_context | sna_instagram_context_sentiment

Possivelmente criar um wizard para que isto seja executado de maneira rápida e eficiente